### PR TITLE
Fix Get-Date call.

### DIFF
--- a/Graphite-PowerShell.ps1
+++ b/Graphite-PowerShell.ps1
@@ -511,7 +511,7 @@ function Send-GraphiteMetric
 	if ($DateTime)
 	{
 		# Convert to a Unix time without any rounding
-		$UnixTime = (Get-Date $DateTime -UFormat % s) -Replace ("[,\.]\d*", "")
+		$UnixTime = (Get-Date $DateTime -UFormat %s) -Replace ("[,\.]\d*", "")
 	}
 	
 	# Create Send-To-Graphite Metric


### PR DESCRIPTION
The format of '% s' causes errors. Changing to '%s' fixes the errors.
