### PR TITLE
Convert all indentation to spaces and all line endings to Windows

### DIFF
--- a/Graphite-PowerShell.ps1
+++ b/Graphite-PowerShell.ps1
@@ -28,103 +28,103 @@ Function Start-StatsToGraphite
         AUTHOR:    Matthew Hodgkins
         WEBSITE:   http://www.hodgkins.net.au
 #>
-	[CmdletBinding()]
-	param ()
-	
-	# Run The Load XML Config Function
-	$Config = Import-XMLConfig -ConfigPath $configPath
-	
-	# Get Last Run Time
-	$lastRunTime = [DateTime]::MinValue
-	
-	# Start Endless Loop
-	While ($True)
-	{
-		# Loop until enough time has passed to run the process again.
-		While ((Get-Date) - $lastRunTime -lt $Config.MetricTimeSpan)
-		{
-			Start-Sleep -Milliseconds 500
-		}
-		
-		# Update the Last Run Time and Use To Track How Long Execution Took
-		$lastRunTime = Get-Date
-		
-		# Take the Sample of the Counter
-		$collections = Get-Counter -Counter $Config.Counters -SampleInterval 1 -MaxSamples 1
-		
-		# Filter the Output of the Counters
-		$samples = $collections.CounterSamples
-		
-		# Verbose
-		Write-Verbose "All Samples Collected"
-		
-		# Convert To The TimeZone of the Graphite Server
-		$convertedTime = Convert-TimeZone -DateTime (Get-Date -Format s) -ToTimeZone $Config.TimeZoneOfGraphiteServer
-		
-		# Get the TargetTime Part of the Script
-		$convertedTime = $convertedTime.TargetTime
-		
-		# Round Time to Nearest Time Period
-		$convertedTime = $convertedTime.AddSeconds(- ($convertedTime.Second % $Config.MetricSendIntervalSeconds))
-		
-		$metricsToSend = @{}
+    [CmdletBinding()]
+    param ()
+    
+    # Run The Load XML Config Function
+    $Config = Import-XMLConfig -ConfigPath $configPath
+    
+    # Get Last Run Time
+    $lastRunTime = [DateTime]::MinValue
+    
+    # Start Endless Loop
+    While ($True)
+    {
+        # Loop until enough time has passed to run the process again.
+        While ((Get-Date) - $lastRunTime -lt $Config.MetricTimeSpan)
+        {
+            Start-Sleep -Milliseconds 500
+        }
+        
+        # Update the Last Run Time and Use To Track How Long Execution Took
+        $lastRunTime = Get-Date
+        
+        # Take the Sample of the Counter
+        $collections = Get-Counter -Counter $Config.Counters -SampleInterval 1 -MaxSamples 1
+        
+        # Filter the Output of the Counters
+        $samples = $collections.CounterSamples
+        
+        # Verbose
+        Write-Verbose "All Samples Collected"
+        
+        # Convert To The TimeZone of the Graphite Server
+        $convertedTime = Convert-TimeZone -DateTime (Get-Date -Format s) -ToTimeZone $Config.TimeZoneOfGraphiteServer
+        
+        # Get the TargetTime Part of the Script
+        $convertedTime = $convertedTime.TargetTime
+        
+        # Round Time to Nearest Time Period
+        $convertedTime = $convertedTime.AddSeconds(- ($convertedTime.Second % $Config.MetricSendIntervalSeconds))
+        
+        $metricsToSend = @{}
 
-		# Loop Through All The Counters
-		ForEach ($sample in $samples)
-		{
-			if ($Config.ShowOutput)
-			{
-				$samplePath = $sample.Path
-				Write-Verbose "Sample Name: $samplePath"
-			}
-			
-			if ($sample.Path -notmatch [regex]$Config.Filters)
-			{
-				# Run the sample path through the ConvertTo-GraphiteMetric function
-				$cleanNameOfSample = ConvertTo-GraphiteMetric -MetricToClean $sample.Path -RemoveUnderscores -NicePhysicalDisks
-				
-				$DebugOut = 'Job Execution Time To Get to Clean Metrics: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
-				Write-Verbose $DebugOut
-				
-				# Build the full metric path
-				$metricPath = $Config.MetricPath + '.' + $cleanNameOfSample
-				
-				$metricsToSend[$metricPath] = $sample.Cookedvalue
-				
-				$DebugOut = 'Job Execution Time To Get to Clean Metrics: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
-				Write-Verbose $DebugOut
-			}
-			
-			else
-			{
-				Write-Verbose "Filtering out Sample Name: $samplePath as it matches something in the filters"
-			}
-		}
+        # Loop Through All The Counters
+        ForEach ($sample in $samples)
+        {
+            if ($Config.ShowOutput)
+            {
+                $samplePath = $sample.Path
+                Write-Verbose "Sample Name: $samplePath"
+            }
+            
+            if ($sample.Path -notmatch [regex]$Config.Filters)
+            {
+                # Run the sample path through the ConvertTo-GraphiteMetric function
+                $cleanNameOfSample = ConvertTo-GraphiteMetric -MetricToClean $sample.Path -RemoveUnderscores -NicePhysicalDisks
+                
+                $DebugOut = 'Job Execution Time To Get to Clean Metrics: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
+                Write-Verbose $DebugOut
+                
+                # Build the full metric path
+                $metricPath = $Config.MetricPath + '.' + $cleanNameOfSample
+                
+                $metricsToSend[$metricPath] = $sample.Cookedvalue
+                
+                $DebugOut = 'Job Execution Time To Get to Clean Metrics: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
+                Write-Verbose $DebugOut
+            }
+            
+            else
+            {
+                Write-Verbose "Filtering out Sample Name: $samplePath as it matches something in the filters"
+            }
+        }
 
-		# Send To Graphite Server
-		
-		# Use Verbose if Verbose output is enabled in the config file.
-		if ($Config.ShowOutput)
-		{
-			Send-BulkGraphiteMetrics -CarbonServer $Config.CarbonServer -CarbonServerPort $Config.CarbonServerPort -Metrics $metricsToSend -DateTime $convertedTime -Verbose
-		}
-		
-		# If config value is not set, don't run command with Verbose switch
-		else
-		{
-			Send-BulkGraphiteMetrics -CarbonServer $Config.CarbonServer -CarbonServerPort $Config.CarbonServerPort -Metrics $metricsToSend -DateTime $convertedTime
-		}
-		
-		# Reloads The Configuration File After the Loop so new counters can be added on the fly
-		$Config = Import-XMLConfig -ConfigPath $configPath
-		
-		if ($Config.ShowOutput)
-		{
-			# Write To Console How Long Execution Took
-			$VerboseOutPut = 'PerfMon Job Execution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
-			Write-Output $VerboseOutPut
-		}
-	}
+        # Send To Graphite Server
+        
+        # Use Verbose if Verbose output is enabled in the config file.
+        if ($Config.ShowOutput)
+        {
+            Send-BulkGraphiteMetrics -CarbonServer $Config.CarbonServer -CarbonServerPort $Config.CarbonServerPort -Metrics $metricsToSend -DateTime $convertedTime -Verbose
+        }
+        
+        # If config value is not set, don't run command with Verbose switch
+        else
+        {
+            Send-BulkGraphiteMetrics -CarbonServer $Config.CarbonServer -CarbonServerPort $Config.CarbonServerPort -Metrics $metricsToSend -DateTime $convertedTime
+        }
+        
+        # Reloads The Configuration File After the Loop so new counters can be added on the fly
+        $Config = Import-XMLConfig -ConfigPath $configPath
+        
+        if ($Config.ShowOutput)
+        {
+            # Write To Console How Long Execution Took
+            $VerboseOutPut = 'PerfMon Job Execution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
+            Write-Output $VerboseOutPut
+        }
+    }
 }
 
 Function Start-SQLStatsToGraphite
@@ -167,171 +167,171 @@ Function Start-SQLStatsToGraphite
         AUTHOR:    Matthew Hodgkins
         WEBSITE:   http://www.hodgkins.net.au
 #>
-	[CmdletBinding()]
-	Param
-	(
-		# Enable Test Mode. Metrics will not be sent to Graphite
-		[Parameter(Mandatory = $false)]
-		[switch]$TestMode
-	)
-	
-	# Run The Load XML Config Function
-	$Config = Import-XMLConfig -ConfigPath $configPath
-	
-	# Doesn’t Run Unless there is SQL Servers in the config file
-	if ($Config.MSSQLServers.Length -eq 0)
-	{
-		Write-Error "There are no SQL Servers in your configuration file. Please add some before running this CmdLet"
-		break
-	}
-	
-	# Check for SQLPS Module
-	if (($listofSQLModules = Get-Module -List SQLPS).Length -eq 1)
-	{
-		# Load The SQL Module
-		Import-Module SQLPS
-	}
-	# Check for the PS SQL SnapIn
-	elseif ((Test-Path ($env:ProgramFiles + '\Microsoft SQL Server\100\Tools\Binn\Microsoft.SqlServer.Management.PSProvider.dll')) -or (Test-Path ($env:ProgramFiles + ' (x86)' + '\Microsoft SQL Server\100\Tools\Binn\Microsoft.SqlServer.Management.PSProvider.dll')))
-	{
-		# Load The SQL SnapIns
-		Add-PSSnapin SqlServerCmdletSnapin100
-		Add-PSSnapin SqlServerProviderSnapin100
-	}
-	# If No Snapin's Found end the function
-	else
-	{
-		Write-Error "Unable to find any SQL CmdLets. Please install them and try again."
-		# End the Function
-		Break
-	}
-	# Get Last Run Time
-	$lastRunTime = [DateTime]::MinValue
-	
-	# Start Endless Loop
-	While ($True)
-	{
-		# Loop until enough time has passed to run the process again.
-		While ((Get-Date) - $lastRunTime -lt $Config.MSSQLMetricTimeSpan)
-		{
-			Start-Sleep -Milliseconds 500
-		}
-		
-		# Update the Last Run Time and Use To Track How Long Execution Took
-		$lastRunTime = Get-Date
-		
-		# Convert To The TimeZone of the Graphite Server
-		$convertedTime = Convert-TimeZone -DateTime (Get-Date -Format s) -ToTimeZone $Config.TimeZoneOfGraphiteServer
-		
-		# Get the TargetTime Part of the Script
-		$convertedTime = $convertedTime.TargetTime
-		
-		# Round Time to Nearest Time Period
-		$convertedTime = $convertedTime.AddSeconds(- ($convertedTime.Second % $Config.MSSQLMetricSendIntervalSeconds))
-		
-		# Loop through each SQL Server
-		ForEach ($sqlServer in $Config.MSSQLServers)
-		{
-			Write-Verbose "Running through SQLServer $($sqlServer.ServerInstance)"
-			# Loop through each query for the SQL server
-			ForEach ($query in $sqlServer.Queries)
-			{
-				Write-Verbose "Current Query $($query.TSQL)"
-				
-				# Run the Invoke-SqlCmd Cmdlet with a username and password only if they are present in the config file
-				if ((($sqlServer.Username).Length -eq 0) -or (($sqlServer.Password).Length -eq 0))
-				{
-					$sqlCmdParams = @{
-						'ServerInstance' = $sqlServer.ServerInstance;
-						'Database' = $query.Database;
-						'Query' = $query.TSQL;
-						'ConnectionTimeout' = $Config.MSSQLConnectTimeout;
-						'QueryTimeout' = $Config.MSSQLQueryTimeout
-					}
-				}
-				# Run SQL cmd using credentials
-				else
-				{
-					$sqlCmdParams = @{
-						'ServerInstance' = $sqlServer.ServerInstance;
-						'Database' = $query.Database;
-						'Query' = $query.TSQL;
-						'ConnectionTimeout' = $Config.MSSQLConnectTimeout;
-						'QueryTimeout' = $Config.MSSQLQueryTimeout;
-						'Username' = $sqlServer.Username;
-						'Password' = $sqlServer.Password
-					}
-				}
-				
-				# Run the SQL Command
-				try
-				{
-					$sqlresult = Invoke-SQLCmd @sqlCmdParams
-					
-					# Build the MetricPath that will be used to send the metric to Graphite
-					$metricPath = $Config.MSSQLMetricPath + '.' + $query.MetricName
-					
-					# Send-GraphiteMetric Command - Verbose and TestMode
-					if ($TestMode)
-					{
-						$sendGraphiteCmdParams = @{
-							CarbonServer = $Config.CarbonServer;
-							CarbonServerPort = $Config.CarbonServerPort;
-							MetricPath = $metricPath;
-							DateTime = $convertedTime;
-							MetricValue = $sqlresult[0];
-							Verbose = $True;
-							TestMode = $True;
-						}
-					}
-					# Send-GraphiteMetric Command - Verbose
-					elseif ($Config.ShowOutput)
-					{
-						$sendGraphiteCmdParams = @{
-							CarbonServer = $Config.CarbonServer;
-							CarbonServerPort = $Config.CarbonServerPort;
-							MetricPath = $metricPath;
-							MetricValue = $sqlresult[0];
-							DateTime = $convertedTime;
-							Verbose = $True;
-						}
-					}
-					# Send-GraphiteMetric Command - Metrics Only
-					else
-					{
-						$sendGraphiteCmdParams = @{
-							CarbonServer = $Config.CarbonServer;
-							CarbonServerPort = $Config.CarbonServerPort;
-							MetricPath = $metricPath;
-							MetricValue = $sqlresult[0];
-							DateTime = $convertedTime;
-						}
-					}
-					
-					Send-GraphiteMetric @sendGraphiteCmdParams
-					
-					Write-Verbose ('Job Exceution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds')
-				}
-				catch
-				{
-					Write-Error "Caught an exception"
-					Write-Error "Exception Type: $($_.Exception.GetType().FullName)"
-					Write-Error "Exception Message: $($_.Exception.Message)"
-				}
-			} #end ForEach Query
-		} #end ForEach SQL Server
-		
-		
-		if ($Config.ShowOutput)
-		{
-			# Write To Console How Long Execuption Took
-			$VerboseOutPut = 'SQL Job Exceution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
-			Write-Output $VerboseOutPut
-		}
-		
-		# Reloads The Configuration File After the Loop so new queries can be added on the fly
-		$Config = Import-XMLConfig -ConfigPath $configPath
-	} #end While Loop
+    [CmdletBinding()]
+    Param
+    (
+        # Enable Test Mode. Metrics will not be sent to Graphite
+        [Parameter(Mandatory = $false)]
+        [switch]$TestMode
+    )
+    
+    # Run The Load XML Config Function
+    $Config = Import-XMLConfig -ConfigPath $configPath
+    
+    # Doesn’t Run Unless there is SQL Servers in the config file
+    if ($Config.MSSQLServers.Length -eq 0)
+    {
+        Write-Error "There are no SQL Servers in your configuration file. Please add some before running this CmdLet"
+        break
+    }
+    
+    # Check for SQLPS Module
+    if (($listofSQLModules = Get-Module -List SQLPS).Length -eq 1)
+    {
+        # Load The SQL Module
+        Import-Module SQLPS
+    }
+    # Check for the PS SQL SnapIn
+    elseif ((Test-Path ($env:ProgramFiles + '\Microsoft SQL Server\100\Tools\Binn\Microsoft.SqlServer.Management.PSProvider.dll')) -or (Test-Path ($env:ProgramFiles + ' (x86)' + '\Microsoft SQL Server\100\Tools\Binn\Microsoft.SqlServer.Management.PSProvider.dll')))
+    {
+        # Load The SQL SnapIns
+        Add-PSSnapin SqlServerCmdletSnapin100
+        Add-PSSnapin SqlServerProviderSnapin100
+    }
+    # If No Snapin's Found end the function
+    else
+    {
+        Write-Error "Unable to find any SQL CmdLets. Please install them and try again."
+        # End the Function
+        Break
+    }
+    # Get Last Run Time
+    $lastRunTime = [DateTime]::MinValue
+    
+    # Start Endless Loop
+    While ($True)
+    {
+        # Loop until enough time has passed to run the process again.
+        While ((Get-Date) - $lastRunTime -lt $Config.MSSQLMetricTimeSpan)
+        {
+            Start-Sleep -Milliseconds 500
+        }
+        
+        # Update the Last Run Time and Use To Track How Long Execution Took
+        $lastRunTime = Get-Date
+        
+        # Convert To The TimeZone of the Graphite Server
+        $convertedTime = Convert-TimeZone -DateTime (Get-Date -Format s) -ToTimeZone $Config.TimeZoneOfGraphiteServer
+        
+        # Get the TargetTime Part of the Script
+        $convertedTime = $convertedTime.TargetTime
+        
+        # Round Time to Nearest Time Period
+        $convertedTime = $convertedTime.AddSeconds(- ($convertedTime.Second % $Config.MSSQLMetricSendIntervalSeconds))
+        
+        # Loop through each SQL Server
+        ForEach ($sqlServer in $Config.MSSQLServers)
+        {
+            Write-Verbose "Running through SQLServer $($sqlServer.ServerInstance)"
+            # Loop through each query for the SQL server
+            ForEach ($query in $sqlServer.Queries)
+            {
+                Write-Verbose "Current Query $($query.TSQL)"
+                
+                # Run the Invoke-SqlCmd Cmdlet with a username and password only if they are present in the config file
+                if ((($sqlServer.Username).Length -eq 0) -or (($sqlServer.Password).Length -eq 0))
+                {
+                    $sqlCmdParams = @{
+                        'ServerInstance' = $sqlServer.ServerInstance;
+                        'Database' = $query.Database;
+                        'Query' = $query.TSQL;
+                        'ConnectionTimeout' = $Config.MSSQLConnectTimeout;
+                        'QueryTimeout' = $Config.MSSQLQueryTimeout
+                    }
+                }
+                # Run SQL cmd using credentials
+                else
+                {
+                    $sqlCmdParams = @{
+                        'ServerInstance' = $sqlServer.ServerInstance;
+                        'Database' = $query.Database;
+                        'Query' = $query.TSQL;
+                        'ConnectionTimeout' = $Config.MSSQLConnectTimeout;
+                        'QueryTimeout' = $Config.MSSQLQueryTimeout;
+                        'Username' = $sqlServer.Username;
+                        'Password' = $sqlServer.Password
+                    }
+                }
+                
+                # Run the SQL Command
+                try
+                {
+                    $sqlresult = Invoke-SQLCmd @sqlCmdParams
+                    
+                    # Build the MetricPath that will be used to send the metric to Graphite
+                    $metricPath = $Config.MSSQLMetricPath + '.' + $query.MetricName
+                    
+                    # Send-GraphiteMetric Command - Verbose and TestMode
+                    if ($TestMode)
+                    {
+                        $sendGraphiteCmdParams = @{
+                            CarbonServer = $Config.CarbonServer;
+                            CarbonServerPort = $Config.CarbonServerPort;
+                            MetricPath = $metricPath;
+                            DateTime = $convertedTime;
+                            MetricValue = $sqlresult[0];
+                            Verbose = $True;
+                            TestMode = $True;
+                        }
+                    }
+                    # Send-GraphiteMetric Command - Verbose
+                    elseif ($Config.ShowOutput)
+                    {
+                        $sendGraphiteCmdParams = @{
+                            CarbonServer = $Config.CarbonServer;
+                            CarbonServerPort = $Config.CarbonServerPort;
+                            MetricPath = $metricPath;
+                            MetricValue = $sqlresult[0];
+                            DateTime = $convertedTime;
+                            Verbose = $True;
+                        }
+                    }
+                    # Send-GraphiteMetric Command - Metrics Only
+                    else
+                    {
+                        $sendGraphiteCmdParams = @{
+                            CarbonServer = $Config.CarbonServer;
+                            CarbonServerPort = $Config.CarbonServerPort;
+                            MetricPath = $metricPath;
+                            MetricValue = $sqlresult[0];
+                            DateTime = $convertedTime;
+                        }
+                    }
+                    
+                    Send-GraphiteMetric @sendGraphiteCmdParams
+                    
+                    Write-Verbose ('Job Exceution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds')
+                }
+                catch
+                {
+                    Write-Error "Caught an exception"
+                    Write-Error "Exception Type: $($_.Exception.GetType().FullName)"
+                    Write-Error "Exception Message: $($_.Exception.Message)"
+                }
+            } #end ForEach Query
+        } #end ForEach SQL Server
+        
+        
+        if ($Config.ShowOutput)
+        {
+            # Write To Console How Long Execuption Took
+            $VerboseOutPut = 'SQL Job Exceution Time: ' + ((Get-Date) - $lastRunTime).TotalSeconds + ' seconds'
+            Write-Output $VerboseOutPut
+        }
+        
+        # Reloads The Configuration File After the Loop so new queries can be added on the fly
+        $Config = Import-XMLConfig -ConfigPath $configPath
+    } #end While Loop
 }
 
 Function ConvertTo-GraphiteMetric
@@ -365,79 +365,79 @@ Function ConvertTo-GraphiteMetric
         AUTHOR:    Matthew Hodgkins
         WEBSITE:   http://www.hodgkins.net.au
 #>
-	param
-	(
-		[CmdletBinding()]
-		[parameter(Mandatory = $true)]
-		[string]$MetricToClean,
-		
-		[parameter(Mandatory = $false)]
-		[switch]$RemoveUnderscores,
-		
-		[parameter(Mandatory = $false)]
-		[switch]$NicePhysicalDisks
-	)
-	
-	# Removing Beginning Backslashes"
-	$cleanNameOfSample = $MetricToClean -replace '^\\\\', ''
-	
-	# Replacing Backslashes After ServerName With dot"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\\\\', '.'
-	
-	# Removing Replacing Colon with Dot"
-	$cleanNameOfSample = $cleanNameOfSample -replace ':', '.'
-	
-	# Changing Fwd Slash To Dash"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\/', '-'
-	
-	# Changing BackSlash To Dot"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\\', '.'
-	
-	# Changing Opening Round Bracket to Dot"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\(', '.'
-	
-	# Removing Closing Round Bracket to Dot"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\)', ''
-	
-	# Removing Square Bracket"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\]', ''
-	
-	# Removing Square Bracket"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\[', ''
-	
-	# Removing Percentage Sign"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\%', ''
-	
-	# Removing Spaces"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\s+', ''
-	
-	# Removing Double Dots"
-	$cleanNameOfSample = $cleanNameOfSample -replace '\.\.', '.'
-	
-	if ($RemoveUnderscores)
-	{
-		Write-Verbose "Removing Underscores as the switch is enabled"
-		$cleanNameOfSample = $cleanNameOfSample -replace '_', ''
-	}
-	
-	if ($NicePhysicalDisks)
-	{
-		Write-Verbose "NicePhyiscalDisks switch is enabled"
-		
-		# Get Drive Letter
-		$driveLetter = ([regex]'physicaldisk\.\d([a-zA-Z])').match($cleanNameOfSample).groups[1].value
-		
-		# Add -drive to the drive letter
-		$cleanNameOfSample = $cleanNameOfSample -replace 'physicaldisk\.\d([a-zA-Z])', ('physicaldisk.' + $driveLetter + '-drive')
-		
-		# Get the new cleaned drive letter
-		$niceDriveLetter = ([regex]'physicaldisk\.(.*)\.avg\.').match($cleanNameOfSample).groups[1].value
-		
-		# Remvoe the .avg. section
-		$cleanNameOfSample = $cleanNameOfSample -replace 'physicaldisk\.(.*)\.avg\.', ('physicaldisk.' + $niceDriveLetter + '.')
-	}
-	
-	Write-Output $cleanNameOfSample
+    param
+    (
+        [CmdletBinding()]
+        [parameter(Mandatory = $true)]
+        [string]$MetricToClean,
+        
+        [parameter(Mandatory = $false)]
+        [switch]$RemoveUnderscores,
+        
+        [parameter(Mandatory = $false)]
+        [switch]$NicePhysicalDisks
+    )
+    
+    # Removing Beginning Backslashes"
+    $cleanNameOfSample = $MetricToClean -replace '^\\\\', ''
+    
+    # Replacing Backslashes After ServerName With dot"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\\\\', '.'
+    
+    # Removing Replacing Colon with Dot"
+    $cleanNameOfSample = $cleanNameOfSample -replace ':', '.'
+    
+    # Changing Fwd Slash To Dash"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\/', '-'
+    
+    # Changing BackSlash To Dot"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\\', '.'
+    
+    # Changing Opening Round Bracket to Dot"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\(', '.'
+    
+    # Removing Closing Round Bracket to Dot"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\)', ''
+    
+    # Removing Square Bracket"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\]', ''
+    
+    # Removing Square Bracket"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\[', ''
+    
+    # Removing Percentage Sign"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\%', ''
+    
+    # Removing Spaces"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\s+', ''
+    
+    # Removing Double Dots"
+    $cleanNameOfSample = $cleanNameOfSample -replace '\.\.', '.'
+    
+    if ($RemoveUnderscores)
+    {
+        Write-Verbose "Removing Underscores as the switch is enabled"
+        $cleanNameOfSample = $cleanNameOfSample -replace '_', ''
+    }
+    
+    if ($NicePhysicalDisks)
+    {
+        Write-Verbose "NicePhyiscalDisks switch is enabled"
+        
+        # Get Drive Letter
+        $driveLetter = ([regex]'physicaldisk\.\d([a-zA-Z])').match($cleanNameOfSample).groups[1].value
+        
+        # Add -drive to the drive letter
+        $cleanNameOfSample = $cleanNameOfSample -replace 'physicaldisk\.\d([a-zA-Z])', ('physicaldisk.' + $driveLetter + '-drive')
+        
+        # Get the new cleaned drive letter
+        $niceDriveLetter = ([regex]'physicaldisk\.(.*)\.avg\.').match($cleanNameOfSample).groups[1].value
+        
+        # Remvoe the .avg. section
+        $cleanNameOfSample = $cleanNameOfSample -replace 'physicaldisk\.(.*)\.avg\.', ('physicaldisk.' + $niceDriveLetter + '.')
+    }
+    
+    Write-Output $cleanNameOfSample
 }
 
 function Send-GraphiteMetric
@@ -481,70 +481,70 @@ function Send-GraphiteMetric
         WEBSITE:   http://www.hodgkins.net.au
 
 #>
-	param
-	(
-		[CmdletBinding(DefaultParametersetName = 'Date Object')]
-		[parameter(Mandatory = $true)]
-		[string]$CarbonServer,
-		
-		[parameter(Mandatory = $false)]
-		[ValidateRange(1, 65535)]
-		[int]$CarbonServerPort = 2003,
-		
-		[parameter(Mandatory = $true)]
-		[string]$MetricPath,
-		
-		[parameter(Mandatory = $true)]
-		[string]$MetricValue,
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Epoch / Unix Time')]
-		[ValidateRange(1, 99999999999999)]
-		[string]$UnixTime,
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Date Object')]
-		[datetime]$DateTime,
-		
-		# Will Display what will be sent to Graphite but not actually send it
-		[Parameter(Mandatory = $false)]
-		[switch]$TestMode
-	)
-	
-	# If Received A DateTime Object - Convert To UnixTime
-	if ($DateTime)
-	{
-		# Convert to a Unix time without any rounding
-		$UnixTime = (Get-Date $DateTime -UFormat %s) -Replace ("[,\.]\d*", "")
-	}
-	
-	# Create Send-To-Graphite Metric
-	$metric = $MetricPath + " " + $MetricValue + " " + $UnixTime
-	
-	Write-Verbose "Metric Received: $metric"
-	
-	# Do not send if TestMode enabled
-	if (!($TestMode))
-	{
-		try
-		{
-			#Stream results to the Carbon server
-			$socket = New-Object System.Net.Sockets.TCPClient
-			$socket.connect($CarbonServer, $CarbonServerPort)
-			$stream = $socket.GetStream()
-			$writer = new-object System.IO.StreamWriter($stream)
-			
-			#Write out metric to the stream.
-			$writer.WriteLine($metric)
-			$writer.Flush() #Flush and write our metrics.
-			$writer.Close()
-			$stream.Close()
-		}
-		catch
-		{
-			Write-Error "Error sending metrics to the Graphite Server. Please check your configuration file"
-		}
-	}
+    param
+    (
+        [CmdletBinding(DefaultParametersetName = 'Date Object')]
+        [parameter(Mandatory = $true)]
+        [string]$CarbonServer,
+        
+        [parameter(Mandatory = $false)]
+        [ValidateRange(1, 65535)]
+        [int]$CarbonServerPort = 2003,
+        
+        [parameter(Mandatory = $true)]
+        [string]$MetricPath,
+        
+        [parameter(Mandatory = $true)]
+        [string]$MetricValue,
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Epoch / Unix Time')]
+        [ValidateRange(1, 99999999999999)]
+        [string]$UnixTime,
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Date Object')]
+        [datetime]$DateTime,
+        
+        # Will Display what will be sent to Graphite but not actually send it
+        [Parameter(Mandatory = $false)]
+        [switch]$TestMode
+    )
+    
+    # If Received A DateTime Object - Convert To UnixTime
+    if ($DateTime)
+    {
+        # Convert to a Unix time without any rounding
+        $UnixTime = (Get-Date $DateTime -UFormat %s) -Replace ("[,\.]\d*", "")
+    }
+    
+    # Create Send-To-Graphite Metric
+    $metric = $MetricPath + " " + $MetricValue + " " + $UnixTime
+    
+    Write-Verbose "Metric Received: $metric"
+    
+    # Do not send if TestMode enabled
+    if (!($TestMode))
+    {
+        try
+        {
+            #Stream results to the Carbon server
+            $socket = New-Object System.Net.Sockets.TCPClient
+            $socket.connect($CarbonServer, $CarbonServerPort)
+            $stream = $socket.GetStream()
+            $writer = new-object System.IO.StreamWriter($stream)
+            
+            #Write out metric to the stream.
+            $writer.WriteLine($metric)
+            $writer.Flush() #Flush and write our metrics.
+            $writer.Close()
+            $stream.Close()
+        }
+        catch
+        {
+            Write-Error "Error sending metrics to the Graphite Server. Please check your configuration file"
+        }
+    }
 }
 
 function Send-BulkGraphiteMetrics
@@ -584,74 +584,74 @@ function Send-BulkGraphiteMetrics
         AUTHOR:    Alexey Kirpichnikov
 
 #>
-	param
-	(
-		[CmdletBinding(DefaultParametersetName = 'Date Object')]
-		[parameter(Mandatory = $true)]
-		[string]$CarbonServer,
-		
-		[parameter(Mandatory = $false)]
-		[ValidateRange(1, 65535)]
-		[int]$CarbonServerPort = 2003,
-		
-		[parameter(Mandatory = $true)]
-		[hashtable]$Metrics,
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Epoch / Unix Time')]
-		[ValidateRange(1, 99999999999999)]
-		[string]$UnixTime,
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Date Object')]
-		[datetime]$DateTime,
-		
-		# Will Display what will be sent to Graphite but not actually send it
-		[Parameter(Mandatory = $false)]
-		[switch]$TestMode
-	)
-	
-	# If Received A DateTime Object - Convert To UnixTime
-	if ($DateTime)
-	{
-		# Convert to a Unix time without any rounding
-		$UnixTime = (Get-Date $DateTime -UFormat %s) -Replace ("[,\.]\d*", "")
-	}
-	
-	# Create Send-To-Graphite Metric
-	$metricStrings = @()
-	foreach ($key in $Metrics.Keys)
-	{
-		$metricStrings += $key + " " + $Metrics[$key] + " " + $UnixTime
-	
+    param
+    (
+        [CmdletBinding(DefaultParametersetName = 'Date Object')]
+        [parameter(Mandatory = $true)]
+        [string]$CarbonServer,
+        
+        [parameter(Mandatory = $false)]
+        [ValidateRange(1, 65535)]
+        [int]$CarbonServerPort = 2003,
+        
+        [parameter(Mandatory = $true)]
+        [hashtable]$Metrics,
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Epoch / Unix Time')]
+        [ValidateRange(1, 99999999999999)]
+        [string]$UnixTime,
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Date Object')]
+        [datetime]$DateTime,
+        
+        # Will Display what will be sent to Graphite but not actually send it
+        [Parameter(Mandatory = $false)]
+        [switch]$TestMode
+    )
+    
+    # If Received A DateTime Object - Convert To UnixTime
+    if ($DateTime)
+    {
+        # Convert to a Unix time without any rounding
+        $UnixTime = (Get-Date $DateTime -UFormat %s) -Replace ("[,\.]\d*", "")
+    }
+    
+    # Create Send-To-Graphite Metric
+    $metricStrings = @()
+    foreach ($key in $Metrics.Keys)
+    {
+        $metricStrings += $key + " " + $Metrics[$key] + " " + $UnixTime
+    
         Write-Verbose ("Metric Received: " + $metricStrings[-1])
-	}
-	
-	# Do not send if TestMode enabled
-	if (!($TestMode))
-	{
-		try
-		{
-			#Stream results to the Carbon server
-			$socket = New-Object System.Net.Sockets.TCPClient
-			$socket.connect($CarbonServer, $CarbonServerPort)
-			$stream = $socket.GetStream()
-			$writer = new-object System.IO.StreamWriter($stream)
-			
-			#Write out metrics to the stream.
-			foreach ($metricString in $metricStrings)
-			{
-				$writer.WriteLine($metricString)
-			}
-			$writer.Flush() #Flush and write our metrics.
-			$writer.Close()
-			$stream.Close()
-		}
-		catch
-		{
-			Write-Error "Error sending metrics to the Graphite Server. Please check your configuration file"
-		}
-	}
+    }
+    
+    # Do not send if TestMode enabled
+    if (!($TestMode))
+    {
+        try
+        {
+            #Stream results to the Carbon server
+            $socket = New-Object System.Net.Sockets.TCPClient
+            $socket.connect($CarbonServer, $CarbonServerPort)
+            $stream = $socket.GetStream()
+            $writer = new-object System.IO.StreamWriter($stream)
+            
+            #Write out metrics to the stream.
+            foreach ($metricString in $metricStrings)
+            {
+                $writer.WriteLine($metricString)
+            }
+            $writer.Flush() #Flush and write our metrics.
+            $writer.Close()
+            $stream.Close()
+        }
+        catch
+        {
+            Write-Error "Error sending metrics to the Graphite Server. Please check your configuration file"
+        }
+    }
 }
 
 function Send-GraphiteEvent
@@ -683,83 +683,83 @@ function Send-GraphiteEvent
         AUTHOR:    Matthew Hodgkins
         WEBSITE:   http://www.hodgkins.net.au
 #>
-	[CmdletBinding()]
-	param
-	(
-		[CmdletBinding()]
-		# The URL of the Graphite Servers Web Interface. For example http://10.4.48.113:8080 or https://myGraphiteServer.local
-		[Parameter(Mandatory = $true)]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[ValidateScript({ $_ -match '^(http|https)\:\/\/.*' })]
-		[string]$GraphiteURL,
-		
-		# The "What" or Topic for the Event
-		[Parameter(Mandatory = $true)]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[Alias("Topic", "Title", "Subject")]
-		[string]$What,
-		
-		# A tag or multiple tags for the event. If you are using multiple tags, separated then with commas
-		[Parameter(Mandatory = $false)]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[string]$Tags,
-		
-		# The body of the event
-		[Parameter(Mandatory = $false)]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[Alias("Body")]
-		[string]$Data
-	)
-	
-	# Check for trailing slash
-	if (!($GraphiteURL.Substring($GraphiteURL.Length - 1) -eq '/'))
-	{
-		$GraphiteURL = $GraphiteURL + '/'
-	}
-	
-	# Construct Full URL to Events API
-	$GraphiteURL = $GraphiteURL + '/events/'
-	
-	# Build an Object to hold the data from the Function
-	$EventObject = New-Object PSObject -Property @{
-		what = $What
-	}
-	
-	# If there are tags
-	if ($Tags)
-	{
-		Add-Member -NotePropertyName tags -NotePropertyValue $Tags -InputObject $EventObject
-	}
-	
-	# If there is data
-	if ($Data)
-	{
-		Add-Member -NotePropertyName data -NotePropertyValue $Data -InputObject $EventObject
-	}
-	
-	$EventObject = $EventObject | ConvertTo-Json
-	
-	Write-Verbose "Json Object:"
-	Write-Verbose $EventObject
-	
-	try
-	{
-		$result = Invoke-WebRequest -Uri $GraphiteURL -Body $EventObject -method Post -ContentType "application/json"
-		Write-Verbose "Returned StatusCode: $($result.StatusCode)"
-		Write-Verbose "Returned StatusDescription: $($result.StatusDescription)"
-	}
-	
-	catch
-	{
-		Write-Error "Caught an exception"
-		Write-Error "Exception Type: $($_.Exception.GetType().FullName)"
-		Write-Error "Exception Message: $($_.Exception.Message)"
-	}
-	
+    [CmdletBinding()]
+    param
+    (
+        [CmdletBinding()]
+        # The URL of the Graphite Servers Web Interface. For example http://10.4.48.113:8080 or https://myGraphiteServer.local
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript({ $_ -match '^(http|https)\:\/\/.*' })]
+        [string]$GraphiteURL,
+        
+        # The "What" or Topic for the Event
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias("Topic", "Title", "Subject")]
+        [string]$What,
+        
+        # A tag or multiple tags for the event. If you are using multiple tags, separated then with commas
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Tags,
+        
+        # The body of the event
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias("Body")]
+        [string]$Data
+    )
+    
+    # Check for trailing slash
+    if (!($GraphiteURL.Substring($GraphiteURL.Length - 1) -eq '/'))
+    {
+        $GraphiteURL = $GraphiteURL + '/'
+    }
+    
+    # Construct Full URL to Events API
+    $GraphiteURL = $GraphiteURL + '/events/'
+    
+    # Build an Object to hold the data from the Function
+    $EventObject = New-Object PSObject -Property @{
+        what = $What
+    }
+    
+    # If there are tags
+    if ($Tags)
+    {
+        Add-Member -NotePropertyName tags -NotePropertyValue $Tags -InputObject $EventObject
+    }
+    
+    # If there is data
+    if ($Data)
+    {
+        Add-Member -NotePropertyName data -NotePropertyValue $Data -InputObject $EventObject
+    }
+    
+    $EventObject = $EventObject | ConvertTo-Json
+    
+    Write-Verbose "Json Object:"
+    Write-Verbose $EventObject
+    
+    try
+    {
+        $result = Invoke-WebRequest -Uri $GraphiteURL -Body $EventObject -method Post -ContentType "application/json"
+        Write-Verbose "Returned StatusCode: $($result.StatusCode)"
+        Write-Verbose "Returned StatusDescription: $($result.StatusDescription)"
+    }
+    
+    catch
+    {
+        Write-Error "Caught an exception"
+        Write-Error "Exception Type: $($_.Exception.GetType().FullName)"
+        Write-Error "Exception Message: $($_.Exception.Message)"
+    }
+    
 }
 
 function Convert-TimeZone
@@ -810,53 +810,53 @@ function Convert-TimeZone
             WEBSITE:   http://www.hodgkins.net.au
 
     #>
-	
-	param
-	(
-		[CmdletBinding(DefaultParametersetName = 'Convert Time Zone')]
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Convert Time Zone')]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[datetime]$DateTime,
-		
-		[Parameter(Mandatory = $true,
-				   ParameterSetName = 'Convert Time Zone')]
-		[ValidateNotNull()]
-		[ValidateNotNullOrEmpty()]
-		[string]$ToTimeZone,
-		
-		[Parameter(Mandatory = $false,
-				   ParameterSetName = 'List Time Zones')]
-		[switch]$ListTimeZones
-	)
-	
-	# Loading dll for Windows 2003 R2
-	[void][System.Reflection.Assembly]::LoadWithPartialName('System.Core')
-	
-	# List TimeZones for the user
-	if ($ListTimeZones)
-	{
-		[System.TimeZoneInfo]::GetSystemTimeZones()
-	}
-	
-	# Run the Function
-	else
-	{
-		$TimeZoneObject = [System.TimeZoneInfo]::GetSystemTimeZones() | Where-Object { $_.id -eq $ToTimeZone }
-		
-		$TargetZoneTime = [System.TimeZoneInfo]::ConvertTime($DateTime, $TimeZoneObject)
-		
-		$OutObject = New-Object -TypeName PSObject -Property @{
-			LocalTime = $DateTime
-			LocalTimeZone = $(([System.TimeZoneInfo]::LOCAL).id)
-			TargetTime = $TargetZoneTime
-			TargetTimeZone = $($TimeZoneObject.id)
-		}
-		
-		Write-Output $OutObject
-	}
+    
+    param
+    (
+        [CmdletBinding(DefaultParametersetName = 'Convert Time Zone')]
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Convert Time Zone')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [datetime]$DateTime,
+        
+        [Parameter(Mandatory = $true,
+                   ParameterSetName = 'Convert Time Zone')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ToTimeZone,
+        
+        [Parameter(Mandatory = $false,
+                   ParameterSetName = 'List Time Zones')]
+        [switch]$ListTimeZones
+    )
+    
+    # Loading dll for Windows 2003 R2
+    [void][System.Reflection.Assembly]::LoadWithPartialName('System.Core')
+    
+    # List TimeZones for the user
+    if ($ListTimeZones)
+    {
+        [System.TimeZoneInfo]::GetSystemTimeZones()
+    }
+    
+    # Run the Function
+    else
+    {
+        $TimeZoneObject = [System.TimeZoneInfo]::GetSystemTimeZones() | Where-Object { $_.id -eq $ToTimeZone }
+        
+        $TargetZoneTime = [System.TimeZoneInfo]::ConvertTime($DateTime, $TimeZoneObject)
+        
+        $OutObject = New-Object -TypeName PSObject -Property @{
+            LocalTime = $DateTime
+            LocalTimeZone = $(([System.TimeZoneInfo]::LOCAL).id)
+            TargetTime = $TargetZoneTime
+            TargetTimeZone = $($TimeZoneObject.id)
+        }
+        
+        Write-Output $OutObject
+    }
 }
 
 Function Import-XMLConfig
@@ -880,82 +880,82 @@ Function Import-XMLConfig
         WEBSITE:   http://www.hodgkins.net.au
 
 #>
-	[CmdletBinding()]
-	Param
-	(
-		# Configuration File Path
-		[Parameter(Mandatory = $true)]
-		$ConfigPath
-	)
-	
-	[hashtable]$Config = @{ }
-	
-	# Load Configuration File
-	$xmlfile = [xml](Get-Content $configPath)
-	
-	#Set the Graphite carbon server location and port number
-	$Config.CarbonServer = $xmlfile.Configuration.Graphite.CarbonServer
-	$Config.CarbonServerPort = $xmlfile.Configuration.Graphite.CarbonServerPort
-	
-	#Get Metric Send Interval From Config
-	[int]$Config.MetricSendIntervalSeconds = $xmlfile.Configuration.Graphite.MetricSendIntervalSeconds
-	
-	# Get the Timezone Of the Graphite Server
-	$Config.TimeZoneOfGraphiteServer = $xmlfile.Configuration.Graphite.TimeZoneOfGraphiteServer
-	
-	# Convert Interval into TimeSpan
-	$Config.MetricTimeSpan = [timespan]::FromSeconds($Config.MetricSendIntervalSeconds)
-	
-	# What is the metric path
-	
-	$Config.MetricPath = $xmlfile.Configuration.Graphite.MetricPath
-	
-	# Convert Value in Configuration File to Bool for showing Verbose Output
-	[bool]$Config.ShowOutput = [System.Convert]::ToBoolean($xmlfile.Configuration.Logging.VerboseOutput)
-	
-	# Create the Performance Counters Array
-	$Config.Counters = @()
-	
-	# Load each row from the configuration file into the counter array
-	ForEach ($counter in $xmlfile.Configuration.PerformanceCounters.Counter)
-	{
-		$Config.Counters += $counter.Name
-	}
-	
-	# Use the filters to create a RegEx string
-	if ($xmlfile.Configuration.Filtering.MetricFilter)
-	{
-		# Load each row from the configuration file into the counter array
-		ForEach ($MetricFilter in $xmlfile.Configuration.Filtering.MetricFilter)
-		{
-			$Config.Filters += $MetricFilter.Name + '|'
-		}
-		
-		# Strip the Last Pipe From the filters string so regex can work against the string.
-		$Config.Filters = $Config.Filters.Substring(0, $Config.Filters.Length - 1)
-	}
-	
-	# If there are no filters, put in something that will never match so all the counters will be allowed through.
-	else
-	{
-		$Config.Filters = 'nothingwillevermatchthishugestring'
-	}
-	
-	# Below is for SQL Metrics
-	$Config.MSSQLMetricPath = $xmlfile.Configuration.MSSQLMetics.MetricPath
-	$Config.MSSQLMetricSendIntervalSeconds = $xmlfile.Configuration.MSSQLMetics.MetricSendIntervalSeconds
-	$Config.MSSQLMetricTimeSpan = [timespan]::FromSeconds($Config.MSSQLMetricSendIntervalSeconds)
-	[int]$Config.MSSQLConnectTimeout = $xmlfile.Configuration.MSSQLMetics.SQLConnectionTimeoutSeconds
-	[int]$Config.MSSQLQueryTimeout = $xmlfile.Configuration.MSSQLMetics.SQLQueryTimeoutSeconds
-	
-	# Create the Performance Counters Array
-	$Config.MSSQLServers = @()
-	
-	ForEach ($sqlServer in $xmlfile.Configuration.MSSQLMetics.SQLServers.SQLServer)
-	{
-		# Load each SQL Server into an array
-		$Config.MSSQLServers += [pscustomobject]@{ ServerInstance = $sqlServer.ServerInstance; Username = $sqlServer.Username; Password = $sqlServer.Password; Queries = $sqlServer.Query }
-	}
-	
-	Return $Config
+    [CmdletBinding()]
+    Param
+    (
+        # Configuration File Path
+        [Parameter(Mandatory = $true)]
+        $ConfigPath
+    )
+    
+    [hashtable]$Config = @{ }
+    
+    # Load Configuration File
+    $xmlfile = [xml](Get-Content $configPath)
+    
+    #Set the Graphite carbon server location and port number
+    $Config.CarbonServer = $xmlfile.Configuration.Graphite.CarbonServer
+    $Config.CarbonServerPort = $xmlfile.Configuration.Graphite.CarbonServerPort
+    
+    #Get Metric Send Interval From Config
+    [int]$Config.MetricSendIntervalSeconds = $xmlfile.Configuration.Graphite.MetricSendIntervalSeconds
+    
+    # Get the Timezone Of the Graphite Server
+    $Config.TimeZoneOfGraphiteServer = $xmlfile.Configuration.Graphite.TimeZoneOfGraphiteServer
+    
+    # Convert Interval into TimeSpan
+    $Config.MetricTimeSpan = [timespan]::FromSeconds($Config.MetricSendIntervalSeconds)
+    
+    # What is the metric path
+    
+    $Config.MetricPath = $xmlfile.Configuration.Graphite.MetricPath
+    
+    # Convert Value in Configuration File to Bool for showing Verbose Output
+    [bool]$Config.ShowOutput = [System.Convert]::ToBoolean($xmlfile.Configuration.Logging.VerboseOutput)
+    
+    # Create the Performance Counters Array
+    $Config.Counters = @()
+    
+    # Load each row from the configuration file into the counter array
+    ForEach ($counter in $xmlfile.Configuration.PerformanceCounters.Counter)
+    {
+        $Config.Counters += $counter.Name
+    }
+    
+    # Use the filters to create a RegEx string
+    if ($xmlfile.Configuration.Filtering.MetricFilter)
+    {
+        # Load each row from the configuration file into the counter array
+        ForEach ($MetricFilter in $xmlfile.Configuration.Filtering.MetricFilter)
+        {
+            $Config.Filters += $MetricFilter.Name + '|'
+        }
+        
+        # Strip the Last Pipe From the filters string so regex can work against the string.
+        $Config.Filters = $Config.Filters.Substring(0, $Config.Filters.Length - 1)
+    }
+    
+    # If there are no filters, put in something that will never match so all the counters will be allowed through.
+    else
+    {
+        $Config.Filters = 'nothingwillevermatchthishugestring'
+    }
+    
+    # Below is for SQL Metrics
+    $Config.MSSQLMetricPath = $xmlfile.Configuration.MSSQLMetics.MetricPath
+    $Config.MSSQLMetricSendIntervalSeconds = $xmlfile.Configuration.MSSQLMetics.MetricSendIntervalSeconds
+    $Config.MSSQLMetricTimeSpan = [timespan]::FromSeconds($Config.MSSQLMetricSendIntervalSeconds)
+    [int]$Config.MSSQLConnectTimeout = $xmlfile.Configuration.MSSQLMetics.SQLConnectionTimeoutSeconds
+    [int]$Config.MSSQLQueryTimeout = $xmlfile.Configuration.MSSQLMetics.SQLQueryTimeoutSeconds
+    
+    # Create the Performance Counters Array
+    $Config.MSSQLServers = @()
+    
+    ForEach ($sqlServer in $xmlfile.Configuration.MSSQLMetics.SQLServers.SQLServer)
+    {
+        # Load each SQL Server into an array
+        $Config.MSSQLServers += [pscustomobject]@{ ServerInstance = $sqlServer.ServerInstance; Username = $sqlServer.Username; Password = $sqlServer.Password; Queries = $sqlServer.Query }
+    }
+    
+    Return $Config
 }

--- a/StatsToGraphiteConfig.xml
+++ b/StatsToGraphiteConfig.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Configuration>
-	<Graphite>
-		<CarbonServer>yourCarbonServerNameOrIP</CarbonServer>
-		<CarbonServerPort>2003</CarbonServerPort>
-		<MetricPath>datacenter1.servers</MetricPath>
-		<MetricSendIntervalSeconds>15</MetricSendIntervalSeconds>
-		<TimeZoneOfGraphiteServer>UTC</TimeZoneOfGraphiteServer>
-	</Graphite>
-	<PerformanceCounters>
-		<Counter Name="\Network Interface(*)\Bytes Received/sec"/>
-		<Counter Name="\Network Interface(*)\Bytes Sent/sec"/>
-		<Counter Name="\Network Interface(*)\Packets Received Unicast/sec"/>
-		<Counter Name="\Network Interface(*)\Packets Sent Unicast/sec"/>
-		<Counter Name="\Network Interface(*)\Packets Received Non-Unicast/sec"/>
-		<Counter Name="\Network Interface(*)\Packets Sent Non-Unicast/sec"/>
-		<Counter Name="\Processor(_Total)\% Processor Time"/>
-		<Counter Name="\Memory\Available MBytes"/>
-		<Counter Name="\Memory\Pages/sec"/>
-		<Counter Name="\Memory\Pages Input/sec"/>
-		<Counter Name="\System\Processor Queue Length"/>
-		<Counter Name="\System\Threads"/>
-		<Counter Name="\PhysicalDisk(*)\Avg. Disk Write Queue Length"/>
-		<Counter Name="\PhysicalDisk(*)\Avg. Disk Read Queue Length"/>
-	</PerformanceCounters>
-	<Filtering>
-		<MetricFilter Name="isatap"/>
-		<MetricFilter Name="teredo tunneling"/>
-	</Filtering>
-	<MSSQLMetics>
-		<MetricPath>datacenter1.sqlmetrics</MetricPath>
-		<MetricSendIntervalSeconds>60</MetricSendIntervalSeconds>
-		<SQLConnectionTimeoutSeconds>5</SQLConnectionTimeoutSeconds>
-		<SQLQueryTimeoutSeconds>5</SQLQueryTimeoutSeconds>
-		<SQLServers>
+    <Graphite>
+        <CarbonServer>yourCarbonServerNameOrIP</CarbonServer>
+        <CarbonServerPort>2003</CarbonServerPort>
+        <MetricPath>datacenter1.servers</MetricPath>
+        <MetricSendIntervalSeconds>15</MetricSendIntervalSeconds>
+        <TimeZoneOfGraphiteServer>UTC</TimeZoneOfGraphiteServer>
+    </Graphite>
+    <PerformanceCounters>
+        <Counter Name="\Network Interface(*)\Bytes Received/sec"/>
+        <Counter Name="\Network Interface(*)\Bytes Sent/sec"/>
+        <Counter Name="\Network Interface(*)\Packets Received Unicast/sec"/>
+        <Counter Name="\Network Interface(*)\Packets Sent Unicast/sec"/>
+        <Counter Name="\Network Interface(*)\Packets Received Non-Unicast/sec"/>
+        <Counter Name="\Network Interface(*)\Packets Sent Non-Unicast/sec"/>
+        <Counter Name="\Processor(_Total)\% Processor Time"/>
+        <Counter Name="\Memory\Available MBytes"/>
+        <Counter Name="\Memory\Pages/sec"/>
+        <Counter Name="\Memory\Pages Input/sec"/>
+        <Counter Name="\System\Processor Queue Length"/>
+        <Counter Name="\System\Threads"/>
+        <Counter Name="\PhysicalDisk(*)\Avg. Disk Write Queue Length"/>
+        <Counter Name="\PhysicalDisk(*)\Avg. Disk Read Queue Length"/>
+    </PerformanceCounters>
+    <Filtering>
+        <MetricFilter Name="isatap"/>
+        <MetricFilter Name="teredo tunneling"/>
+    </Filtering>
+    <MSSQLMetics>
+        <MetricPath>datacenter1.sqlmetrics</MetricPath>
+        <MetricSendIntervalSeconds>60</MetricSendIntervalSeconds>
+        <SQLConnectionTimeoutSeconds>5</SQLConnectionTimeoutSeconds>
+        <SQLQueryTimeoutSeconds>5</SQLQueryTimeoutSeconds>
+        <SQLServers>
             <!-- A SQL Server Connection Using SQL Authentication -->
-			<SQLServer ServerInstance="(localdb)\v11.0" Username="sa" Password="PASSWORD1!">
-				<Query Database="mydb" MetricName="mydb.userlist.rowcount" TSQL="select count(userListID) From [dbo].[userList]"/>
-				<Query Database="mydb" MetricName="mydb.userlist.ukemails" TSQL="select count(userListID) From [dbo].[userList] Where Emails like '%.uk%'"/>
-			</SQLServer>
+            <SQLServer ServerInstance="(localdb)\v11.0" Username="sa" Password="PASSWORD1!">
+                <Query Database="mydb" MetricName="mydb.userlist.rowcount" TSQL="select count(userListID) From [dbo].[userList]"/>
+                <Query Database="mydb" MetricName="mydb.userlist.ukemails" TSQL="select count(userListID) From [dbo].[userList] Where Emails like '%.uk%'"/>
+            </SQLServer>
             <!-- A SQL Server Connection Using Windows Authentication. The credentials from the running PowerShell session will be used. -->
-			<SQLServer ServerInstance="MSSQLServer" Username="" Password="">
-				<Query Database="citydb" MetricName="citydb.cities.navadwipkota" TSQL="Select COUNT (city) from [dbo].[cities] Where City = 'Navadwip' OR City = 'Kota'"/>
+            <SQLServer ServerInstance="MSSQLServer" Username="" Password="">
+                <Query Database="citydb" MetricName="citydb.cities.navadwipkota" TSQL="Select COUNT (city) from [dbo].[cities] Where City = 'Navadwip' OR City = 'Kota'"/>
                 <!-- An example query SQL query using a greater-than symbol. The symbol must be replaced with an XML Entity References. List here - http://msdn.microsoft.com/en-us/library/windows/desktop/dd892769%28v=vs.85%29.aspx -->
                 <Query Database="addressbook" MetricName="people.ages.over30" TSQL="Select COUNT (personid) from [dbo].[tblAddressBook] Where Age &gt; 30"/>
-			</SQLServer>
-		</SQLServers>
-	</MSSQLMetics>
-	<Logging>
-		<VerboseOutput>True</VerboseOutput>
-	</Logging>
+            </SQLServer>
+        </SQLServers>
+    </MSSQLMetics>
+    <Logging>
+        <VerboseOutput>True</VerboseOutput>
+    </Logging>
 </Configuration>


### PR DESCRIPTION
Seems like a large change, but in fact it is simple and automatic:
1. Conversion of line endings to Windows format (\r\n). Sometimes it is necessary to look at configuration/code on a production machine, where you don't have decent text editors. Unix line endings make text in Notepad look like a mess. It is unlikely that you use these scripts in Unix environments, thus it is more convenient to have Windows line endings everywhere.
2. Conversion of indentation to spaces. In my previous pull request I noticed that some indentation looks ugly in GitHub diff. This was because of mixed tabs and spaces, which I didn't notice earlier. I took liberty to convert all indentation to 4 spaces per level.

I made conversions automatically in Sublime Text editor, so I hope that I didn't introduce any bugs.
