### PR TITLE
Don't add empty MetricPath + ability to use a different config file for Start-StatsToGraphite

### DIFF
--- a/Functions/Start-StatsToGraphite.ps1
+++ b/Functions/Start-StatsToGraphite.ps1
@@ -18,6 +18,9 @@ Function Start-StatsToGraphite
 
     .Parameter SqlMetrics
         Includes SQL Metrics defined in XML config
+        
+    .Parameter ConfigXMLPath
+        Uses this configuration file instead of the one inside the module folder
 
     .Example
         PS> Start-StatsToGraphite
@@ -51,8 +54,18 @@ Function Start-StatsToGraphite
         [Parameter(Mandatory = $false)]
         [switch]$TestMode,
         [switch]$ExcludePerfCounters = $false,
-        [switch]$SqlMetrics = $false
+        [switch]$SqlMetrics = $false,
+        [string]$ConfigXMLPath
     )
+
+    # Override the config path set in the module if one is provided explicitly
+    if (-not [string]::IsNullOrWhiteSpace($ConfigXMLPath)) {
+        $configPath = $ConfigXMLPath
+    }
+
+    if (-not (Test-Path -PathType Leaf -LiteralPath $configPath)){
+        throw "Cannot find configuration file - $configPath"
+    }
 
     # Run The Load XML Config Function
     $Config = Import-XMLConfig -ConfigPath $configPath

--- a/Functions/Start-StatsToGraphite.ps1
+++ b/Functions/Start-StatsToGraphite.ps1
@@ -142,7 +142,11 @@ Function Start-StatsToGraphite
                     $cleanNameOfSample = ConvertTo-GraphiteMetric -MetricToClean $sample.Path -HostName $Config.NodeHostName -MetricReplacementHash $Config.MetricReplace
 
                     # Build the full metric path
-                    $metricPath = $Config.MetricPath + '.' + $cleanNameOfSample
+                    if (-not [string]::IsNullOrWhiteSpace($Config.MetricPath)) {
+                        $metricPath = $Config.MetricPath + '.' + $cleanNameOfSample
+                    } else {
+                        $metricPath = $cleanNameOfSample
+                    }
 
                     $metricsToSend[$metricPath] = $sample.Cookedvalue
                 }


### PR DESCRIPTION
Small tweaks that might be useful.