### PR TITLE
Fix DateTime to Unix Time in Send-GraphiteMetric

### DIFF
--- a/Functions/Send-GraphiteMetric.ps1
+++ b/Functions/Send-GraphiteMetric.ps1
@@ -76,8 +76,10 @@ function Send-GraphiteMetric
     # If Received A DateTime Object - Convert To UnixTime
     if ($DateTime)
     {
+        $utcDate = $DateTime.ToUniversalTime()
+
         # Convert to a Unix time without any rounding
-        $UnixTime = [uint64]$DateTime.ToUniversalTime()
+        [uint64]$UnixTime = [double]::Parse((Get-Date -Date $utcDate -UFormat %s))
     }
 
     # Create Send-To-Graphite Metric


### PR DESCRIPTION
Fix for #59 

I've just copied the DateTime conversaion that is used in Send-BulkGraphiteMetrics